### PR TITLE
feat: add liquid glass effect to layouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@flowbite-svelte-plugins/chart": "^0.2.4",
     "flowbite-svelte": "1.11.4",
     "flowbite-svelte-icons": "^2.2.1",
+    "liquid-glass-svelte": "^1.2.0",
     "tailwind-merge": "^3.3.1"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       flowbite-svelte-icons:
         specifier: ^2.2.1
         version: 2.2.1(svelte@5.38.0)
+      liquid-glass-svelte:
+        specifier: ^1.2.0
+        version: 1.2.0(svelte@5.38.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -863,6 +866,9 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/to-px@1.1.4':
+    resolution: {integrity: sha512-t8imv37xCZ5yS7ff9g8/3iRwfqx6ro8h3qkI1F1gjqdeu7q5/CxyjDs/EIHbdoEH89SdGuUC+SU27CWUZQ/Jtg==}
+
   '@typescript-eslint/eslint-plugin@8.39.0':
     resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1631,6 +1637,11 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  liquid-glass-svelte@1.2.0:
+    resolution: {integrity: sha512-zKV5UITxQ6vPiFGl/fVemQUmu6qCHEPpxynhJVE7YqNhQs+Y9+E97GsBI8D9qZ4iZcHOL5IusQhW9ITEiky3MQ==}
+    peerDependencies:
+      svelte: ^5.0.0
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
@@ -1785,6 +1796,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-unit@1.0.1:
+    resolution: {integrity: sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -2234,6 +2248,9 @@ packages:
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
+
+  to-px@1.1.0:
+    resolution: {integrity: sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3161,6 +3178,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/to-px@1.1.4': {}
+
   '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -3979,6 +3998,12 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  liquid-glass-svelte@1.2.0(svelte@5.38.0):
+    dependencies:
+      '@types/to-px': 1.1.4
+      svelte: 5.38.0
+      to-px: 1.1.0
+
   locate-character@3.0.0: {}
 
   locate-path@5.0.0:
@@ -4103,6 +4128,8 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-unit@1.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -4465,6 +4492,10 @@ snapshots:
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
+
+  to-px@1.1.0:
+    dependencies:
+      parse-unit: 1.0.1
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/routes/(no-sidebar)/+layout.svelte
+++ b/src/routes/(no-sidebar)/+layout.svelte
@@ -2,6 +2,7 @@
   import Footer from '../(no-sidebar)/Footer.svelte';
   import Navbar from '../(sidebar)/Navbar.svelte';
   import type { Snippet } from 'svelte';
+  import { LiquidGlass } from 'liquid-glass-svelte';
   import '../../app.css';
   interface Props {
     children: Snippet;
@@ -9,10 +10,12 @@
   let { children }: Props = $props();
 </script>
 
-<header class="fixed top-0 z-40 mx-auto w-full flex-none border-b border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-800">
-  <Navbar />
-</header>
-<div class="mx-auto max-w-screen-2xl pt-[70px]">
-  {@render children()}
-  <Footer />
-</div>
+<LiquidGlass class="min-h-screen">
+  <header class="fixed top-0 z-40 mx-auto w-full flex-none border-b border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-800">
+    <Navbar />
+  </header>
+  <div class="mx-auto max-w-screen-2xl pt-[70px]">
+    {@render children()}
+    <Footer />
+  </div>
+</LiquidGlass>

--- a/src/routes/(sidebar)/+layout.svelte
+++ b/src/routes/(sidebar)/+layout.svelte
@@ -2,6 +2,7 @@
   import '../../app.css';
   import Navbar from './Navbar.svelte';
   import Sidebar from './Sidebar.svelte';
+  import { LiquidGlass } from 'liquid-glass-svelte';
   import type { LayoutProps } from './$types';
 
   interface Route {
@@ -15,12 +16,14 @@
   let drawerHidden = $state(false);
 </script>
 
-<header class="fixed top-0 z-40 mx-auto w-full flex-none border-b border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-800">
-  <Navbar bind:drawerHidden />
-</header>
-<div class="overflow-hidden lg:flex">
-  <Sidebar bind:drawerHidden {docsRoute} />
-  <div class="relative h-full w-full overflow-y-auto pt-[70px] lg:ml-64">
-    {@render children()}
+<LiquidGlass class="min-h-screen">
+  <header class="fixed top-0 z-40 mx-auto w-full flex-none border-b border-gray-200 bg-white dark:border-gray-600 dark:bg-gray-800">
+    <Navbar bind:drawerHidden />
+  </header>
+  <div class="overflow-hidden lg:flex">
+    <Sidebar bind:drawerHidden {docsRoute} />
+    <div class="relative h-full w-full overflow-y-auto pt-[70px] lg:ml-64">
+      {@render children()}
+    </div>
   </div>
-</div>
+</LiquidGlass>


### PR DESCRIPTION
## Summary
- add liquid-glass-svelte dependency
- wrap sidebar and no-sidebar layouts in LiquidGlass for glassmorphism look

## Testing
- `pnpm lint` (fails: Code style issues found in 4 files)
- `pnpm test` (fails: webServer unable to start due to missing ENV)

------
https://chatgpt.com/codex/tasks/task_e_68a713667c1c8326afe34728034b08d9